### PR TITLE
Doc: add an example for GitHub Actions

### DIFF
--- a/docs/docs/CI/README.md
+++ b/docs/docs/CI/README.md
@@ -10,6 +10,8 @@ permalink: gradle/ci/
 **Hood** gives you the ability to integrate the benchmark comparison into your `CI`
  and integrate the result into a `Github` pull request.
 
+It provides `compareBenchmarksCI` Gradle task which compares 2 reports from a benchmark and then it creates a new comment with the comparison result in the pull request. For instance, [look at this comment](https://github.com/47degrees/helios/pull/137#issuecomment-597753181). If new commits are added to the same pull request, the comment will be updated with the new comparison result.
+
 The `compareBenchmarksCI` task has parameters in common with the `compareBenchmarks` task:
  - **previousBenchmarkPath**: File with previous or master benchmark location. By default: `master.csv`.
  - **currentBenchmarkPath**: List of files with current or pull request benchmark location. By default: an `empty list`.
@@ -28,11 +30,12 @@ These extra parameters are necessary for the `CI` integration:
  - **token**: The `Github` access token.
  - **repositoryOwner**: The repository owner.
  - **repositoryName**: The repository name.
- - **pullRequestSha**: The sha for the Pull Request. The environment variable `TRAVIS_PULL_REQUEST_SHA` on Travis CI.
- - **pullRequestNumber**: The number of the Pull Request. The environment variable `TRAVIS_PULL_REQUEST` on Travis CI.
- - **statusTargetUrl**: The URL to the CI job. The environment variable `TRAVIS_JOB_WEB_URL` on Travis CI. Optional.
+ - **pullRequestSha**: The sha for the Pull Request.
+ - **pullRequestNumber**: The number of the Pull Request.
+ - **statusTargetUrl**: The URL to the CI job. Optional.
 
 ***Note***: Currently, **Hood** only supports `CSV` and `JSON` based benchmarks with cross comparison available.
+
 ***Note 2***: If the `CI` integration is not available because one of the requested fields above is not defined,
   the task `compareBenchmarksCI` will be executed in the same way as `compareBenchmarks`.
 
@@ -45,7 +48,54 @@ The task can send the result to a file with the following parameters:
 
 ***Note***: To print a `JSON` output file, all the benchmarks must be in `JSON` format. `CSV` benchmarks will be ignored.
 
-## Configuration example
+## Configuration examples
+
+### For GitHub Actions
+
+There isnt't an environment variable for the pull request number when writing this documentation. Please, check [the default environment variables list](https://help.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables#default-environment-variables) in case that environment variable already exists. Meanwhile here a trick to get it before calling the Gradle task in the GitHub Action:
+
+```
+export PULL_REQUEST_NUMBER=$(echo $GITHUB_REF | cut -d/ -f3)
+./gradlew :<module>:compareBenchmarksCI
+```
+
+An example of the configuration for the `compareBenchmarksCI` task:
+
+
+<fortyseven-codetab data-languages='["Groovy", "Kotlin"]' markdown="block">
+```groovy
+compareBenchmarksCI {
+  previousBenchmarkPath = file("$rootDir/hood_master/build/reports/master_benchmark.json")
+  currentBenchmarkPath = [file("$rootDir/build/reports/hood_benchmark.json")]
+  outputToFile = true
+  outputFormat = "json"
+  benchmarkThreshold = ["Parsing": 250.00, "Decodingfromraw": 250.00]
+  token = System.getenv("GITHUB_ACCESS_TOKEN")
+  repositoryOwner = "47degrees"
+  repositoryName = "hood"
+  pullRequestSha = System.getenv("GITHUB_SHA")
+  pullRequestNumber = (System.getenv("PULL_REQUEST_NUMBER") != "false") ? System.getenv("PULL_REQUEST_NUMBER")?.toInteger() : -1
+}
+```
+
+```kotlin
+tasks.compareBenchmarksCI {
+  previousBenchmarkPath = file("$rootDir/hood_master/build/reports/master_benchmark.json")
+  currentBenchmarkPath = listOf(file("$rootDir/build/reports/hood_benchmark.json"))
+  outputToFile = true
+  outputFormat = "json"
+  benchmarkThreshold = mapOf("Parsing" to 250.00, "Decodingfromraw" to 250.00)
+  token = System.getenv("GITHUB_ACCESS_TOKEN")
+  repositoryOwner = "47degrees"
+  repositoryName = "hood"
+  pullRequestSha = System.getenv("GITHUB_SHA")
+  pullRequestNumber =
+    if (System.getenv("PULL_REQUEST_NUMBER") != "false") System.getenv("PULL_REQUEST_NUMBER").toInt() else -1
+}
+```
+</fortyseven-codetab>
+
+### For Travis CI
 
 <fortyseven-codetab data-languages='["Groovy", "Kotlin"]' markdown="block">
 ```groovy


### PR DESCRIPTION
Some missing documentation after [integrating Hood into Arrow Fx library](https://github.com/arrow-kt/arrow-fx/pull/159).