### PR TITLE
Configuration: Just one PR for RELEASE deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Hood
 
+[![Maven metadata URL](https://img.shields.io/maven-metadata/v?color=blue&label=latest%20release&metadataUrl=https%3A%2F%2Fplugins.gradle.org%2Fm2%2Fcom%2F47deg%2Fhood%2Fmaven-metadata.xml)](https://plugins.gradle.org/plugin/com.47deg.hood)
+
 **Hood** is a `Gradle` plugin to compare benchmarks and set the result as a `Github` status for a `Pull Request`.
 **Hood** is built on [Arrow](https://arrow-kt.io/), a Functional companion to Kotlin's Standard Library.
 

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,6 @@ plugins {
   id "maven-publish"
   id "com.gradle.plugin-publish" version "0.11.0"
   id "org.jetbrains.kotlin.jvm" version "1.3.71"
-  id "com.jfrog.bintray" version "1.8.5"
   id "com.jfrog.artifactory" version "4.15.2"
 }
 
@@ -94,19 +93,4 @@ artifactory {
             publications 'HoodPublication'
         }
     }
-}
-
-bintray {
-  publish = true
-  user = findPropertyOrEnv("BINTRAY_USER") ?: "no.bintray.user"
-  key = findPropertyOrEnv("BINTRAY_API_KEY") ?: "no.bintray.api.key"
-  publications = ["HoodPublication"]
-  configurations = ["archives"]
-  pkg {
-    repo = "hood"
-    name = project.name
-    userOrg = POM_DEVELOPER_ID
-    licenses = ["Apache-2.0"]
-    vcsUrl = "https://github.com/47degrees/hood.git"
-  }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,7 @@ plugins {
   id "com.gradle.plugin-publish" version "0.11.0"
   id "org.jetbrains.kotlin.jvm" version "1.3.71"
   id "com.jfrog.bintray" version "1.8.5"
+  id "com.jfrog.artifactory" version "4.15.2"
 }
 
 repositories {
@@ -79,6 +80,20 @@ pluginBundle {
 
 def findPropertyOrEnv(String key) {
   [project.properties[key], System.getenv(key)].find { it != null }
+}
+
+artifactory {
+    contextUrl = 'https://oss.jfrog.org'
+    publish {
+        repository {
+            repoKey = 'oss-snapshot-local'
+            username = findPropertyOrEnv("BINTRAY_USER") ?: "no.bintray.user"
+            password = findPropertyOrEnv("BINTRAY_API_KEY") ?: "no.bintray.api.key"
+        }
+        defaults {
+            publications 'HoodPublication'
+        }
+    }
 }
 
 bintray {

--- a/deploy-scripts/deploy.sh
+++ b/deploy-scripts/deploy.sh
@@ -7,9 +7,9 @@ if [ "$TRAVIS_BRANCH" == "master" ]; then
     if [[ "$VERSION_NAME" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
         echo "Starting script for Release $VERSION_NAME"
         . $(dirname $0)/deploy_release.sh
-#    elif [[ "$VERSION_NAME" == *-SNAPSHOT ]]; then
-#        echo "Starting script for Snapshot Release $VERSION_NAME"
-#        . $(dirname $0)/deploy_snapshot.sh
+    elif [[ "$VERSION_NAME" == *-SNAPSHOT ]]; then
+        echo "Starting script for Snapshot $VERSION_NAME"
+        . $(dirname $0)/deploy_snapshot.sh
     else
         echo "No deploy script matched version '$VERSION_NAME' on master"
     fi

--- a/deploy-scripts/deploy_common.sh
+++ b/deploy-scripts/deploy_common.sh
@@ -14,9 +14,14 @@ function fail {
 
 SLUG="47degrees/hood"
 BRANCH="master"
+
+#
+# If release_version isn't published in Gradle Plugin Portal, version value is replaced by release_version value
+#
 RELEASE_VERSION=$(getProperty "release_version")
-LATEST_PUBLISHED_VERSION=$(curl https://dl.bintray.com/47deg/hood/com/47deg/hood/maven-metadata.xml | grep latest | cut -d'>' -f2 | cut -d'<' -f1)
+LATEST_PUBLISHED_VERSION=$(curl https://plugins.gradle.org/m2/com/47deg/hood/maven-metadata.xml | grep latest | cut -d'>' -f2 | cut -d'<' -f1)
 if [ "$RELEASE_VERSION" != "$LATEST_PUBLISHED_VERSION" ]; then
     sed -i "s/version.*/version=$RELEASE_VERSION/g" gradle.properties
 fi
+
 VERSION_NAME=$(getProperty "version")

--- a/deploy-scripts/deploy_common.sh
+++ b/deploy-scripts/deploy_common.sh
@@ -3,7 +3,7 @@ set -e
 
 function getProperty {
     PROP_KEY=$1
-    PROP_VALUE=`cat gradle.properties | grep "$PROP_KEY" | cut -d'=' -f2`
+    PROP_VALUE=`cat gradle.properties | grep -e "^$PROP_KEY=" | cut -d'=' -f2`
     echo $PROP_VALUE
 }
 
@@ -12,6 +12,12 @@ function fail {
     exit -1
 }
 
+
 SLUG="47degrees/hood"
 BRANCH="master"
+RELEASE_VERSION=$(getProperty "release_version")
+LATEST_PUBLISHED_VERSION=$(curl https://dl.bintray.com/47deg/hood/com/47deg/hood/maven-metadata.xml | grep latest | cut -d'>' -f2 | cut -d'<' -f1)
+if [ "$RELEASE_VERSION" != "$LATEST_PUBLISHED_VERSION" ]; then
+    sed -i "s/version.*/version=$RELEASE_VERSION/g" gradle.properties
+fi
 VERSION_NAME=$(getProperty "version")

--- a/deploy-scripts/deploy_common.sh
+++ b/deploy-scripts/deploy_common.sh
@@ -16,7 +16,7 @@ SLUG="47degrees/hood"
 BRANCH="master"
 
 #
-# If release_version isn't published in Gradle Plugin Portal, version value is replaced by release_version value
+# If 'release_version' isn't published in Gradle Plugin Portal, 'version' value is replaced by 'release_version' value
 #
 RELEASE_VERSION=$(getProperty "release_version")
 LATEST_PUBLISHED_VERSION=$(curl https://plugins.gradle.org/m2/com/47deg/hood/maven-metadata.xml | grep latest | cut -d'>' -f2 | cut -d'<' -f1)

--- a/deploy-scripts/deploy_common.sh
+++ b/deploy-scripts/deploy_common.sh
@@ -12,7 +12,6 @@ function fail {
     exit -1
 }
 
-
 SLUG="47degrees/hood"
 BRANCH="master"
 RELEASE_VERSION=$(getProperty "release_version")

--- a/deploy-scripts/deploy_release.sh
+++ b/deploy-scripts/deploy_release.sh
@@ -14,7 +14,6 @@ elif [ "$TRAVIS_BRANCH" != "$BRANCH" ]; then
 elif ! [[ "$VERSION_NAME" =~ $VERSION_PATTERN ]]; then
   fail "Failed release deployment: wrong version. Expected '$VERSION_NAME' to have pattern 'X.Y.Z'"
 else
-  ./gradlew bintrayUpload
   ./gradlew -Dgradle.publish.key=$GRADLE_PUBLISH_KEY -Dgradle.publish.secret=$GRADLE_PUBLISH_SECRET publishPlugins
   echo "Release '$VERSION_NAME' deployed!"
 fi

--- a/deploy-scripts/deploy_snapshot.sh
+++ b/deploy-scripts/deploy_snapshot.sh
@@ -14,6 +14,6 @@ elif [ "$TRAVIS_BRANCH" != "$BRANCH" ]; then
 elif ! [[ "$VERSION_NAME" =~ $VERSION_PATTERN ]]; then
   echo "Skipping snapshot deployment '$VERSION_NAME': This is probably a pre-release build"
 else
-  ./gradlew bintrayUpload
+  ./gradlew artifactoryPublish
   echo "Snapshot '$VERSION_NAME' deployed!"
 fi

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,6 +4,12 @@ group=com.47deg
 version=0.8.2-SNAPSHOT
 # Just RELEASE versions
 release_version=0.8.1
+#
+# NOTE:
+#
+#   Update 'version' and 'release_version' when releasing.
+#   If 'release_version' isn't published, 'version' value will be replaced by 'release_version' value automatically when deploying.
+#   See deploy-scripts/deploy_common.sh
 
 # Gradle options
 org.gradle.warning.mode=all

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,9 @@
 # Package definitions
 group=com.47deg
-version=0.8.1
+# Just SNAPSHOT versions
+version=0.8.2-SNAPSHOT
+# Just RELEASE versions
+release_version=0.8.1
 
 # Gradle options
 org.gradle.warning.mode=all


### PR DESCRIPTION
# How it works

So far:

```
version={ SNAPSHOT version | RELEASE version }
```

so it's necessary to prepare 2 pull request during release time.

New proposal:

```
version={ SNAPSHOT version }
release_version={ RELEASE version }
```

If `release_version` property value isn't deployed then it replaces `version` property value.

# Examples

## SNAPSHOT deployment

For the current content of `gradle.properties` in this PR:

```
version=0.8.2-SNAPSHOT
release_version=0.8.1
```

then:

```
Starting script for Snapshot 0.8.2-SNAPSHOT
...
```

because `0.8.1` is already deployed.

## Release time

For this content of `gradle.properties`:

```
version=0.8.3-SNAPSHOT
release_version=0.8.2
```

then:

```
Starting script for Release 0.8.2
...
```

After deploying `0.8.2`, next PR will raise:

```
Starting script for Snapshot 0.8.3-SNAPSHOT
...
```

# Notes

## About next SNAPSHOT

I suppose that the next SNAPSHOT is:

```
version=0.8.2-SNAPSHOT
```

However, maybe it's not the desired next snapshot, so please, feel free to change it.

## About publication

This PR removes the publication into Bintray for releases because Gradle Plugin Portal is being used now.