### PR TITLE
Use Maven Publish plugin to publish into OSS

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,6 @@ plugins {
   id "maven-publish"
   id "com.gradle.plugin-publish" version "0.11.0"
   id "org.jetbrains.kotlin.jvm" version "1.3.71"
-  id "com.jfrog.artifactory" version "4.15.2"
 }
 
 repositories {
@@ -81,16 +80,23 @@ def findPropertyOrEnv(String key) {
   [project.properties[key], System.getenv(key)].find { it != null }
 }
 
-artifactory {
-    contextUrl = 'https://oss.jfrog.org'
-    publish {
-        repository {
-            repoKey = 'oss-snapshot-local'
-            username = findPropertyOrEnv("BINTRAY_USER") ?: "no.bintray.user"
-            password = findPropertyOrEnv("BINTRAY_API_KEY") ?: "no.bintray.api.key"
+publishing {
+    publications {
+        myPlatform(MavenPublication) {
+            groupId = group
+            artifactId = POM_ARTIFACT_ID
+            version = version
+
+            from components.java
         }
-        defaults {
-            publications 'HoodPublication'
+    }
+    repositories {
+        maven {
+            credentials {
+                username findPropertyOrEnv("BINTRAY_USER") ?: "no.bintray.user"
+                password findPropertyOrEnv("BINTRAY_API_KEY") ?: "no.bintray.api.key"
+            }
+            url = "https://oss.jfrog.org/artifactory/oss-snapshot-local"
         }
     }
 }

--- a/deploy-scripts/deploy_snapshot.sh
+++ b/deploy-scripts/deploy_snapshot.sh
@@ -14,6 +14,6 @@ elif [ "$TRAVIS_BRANCH" != "$BRANCH" ]; then
 elif ! [[ "$VERSION_NAME" =~ $VERSION_PATTERN ]]; then
   echo "Skipping snapshot deployment '$VERSION_NAME': This is probably a pre-release build"
 else
-  ./gradlew artifactoryPublish
+  ./gradlew publish
   echo "Snapshot '$VERSION_NAME' deployed!"
 fi


### PR DESCRIPTION
The use of `artifactory` plugin failed because of the credentials. This PR replaces it by an existing plugin: `maven-publish`.