### PR TITLE
Fix SNAPSHOT publication

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ jobs:
   include:
     - stage: build
       script:
-        - ./gradlew clean build test
+        - ./gradlew clean build
     - stage: deploy-site
       install:
         - rvm use 2.6.0 --install --fuzzy

--- a/build.gradle
+++ b/build.gradle
@@ -52,51 +52,19 @@ test {
   useJUnitPlatform()
 }
 
-apply from: rootProject.file("gradle/gradle-mvn-push.gradle")
-
-gradlePlugin {
-  plugins {
-    hood {
-      id = "com.47deg.hood"
-      implementationClass = "com.fortysevendeg.hood.HoodPlugin"
-    }
-  }
+task sourcesJar(type: Jar, dependsOn: classes) {
+  archiveClassifier = "sources"
+  from sourceSets.main.allSource,
+      "build/generated/source/kapt/main",
+      "build/generated/source/kapt/debug",
+      "build/generated/source/kapt/release",
+      "build/generated/source/kaptKotlin/main",
+      "build/generated/source/kaptKotlin/debug",
+      "build/generated/source/kaptKotlin/release",
+      "build/tmp/kapt/main/kotlinGenerated"
 }
 
-pluginBundle {
-  website = "https://47degrees.github.io/hood/"
-  vcsUrl = "https://github.com/47degrees/hood"
-  description = "The plugin to manage benchmarks on your CI"
-  tags = ["kotlin", "arrow", "hood", "plugin", "benchmark", "comparison"]
-
-  plugins {
-    hood {
-      displayName = "Hood Gradle Plugin"
-    }
-  }
-}
-
-def findPropertyOrEnv(String key) {
-  [project.properties[key], System.getenv(key)].find { it != null }
-}
-
-publishing {
-    publications {
-        myPlatform(MavenPublication) {
-            groupId = group
-            artifactId = POM_ARTIFACT_ID
-            version = version
-
-            from components.java
-        }
-    }
-    repositories {
-        maven {
-            credentials {
-                username findPropertyOrEnv("BINTRAY_USER") ?: "no.bintray.user"
-                password findPropertyOrEnv("BINTRAY_API_KEY") ?: "no.bintray.api.key"
-            }
-            url = "https://oss.jfrog.org/artifactory/oss-snapshot-local"
-        }
-    }
+task javadocJar(type: Jar, dependsOn: javadoc) {
+  archiveClassifier = "javadoc"
+  from javadoc.destinationDir
 }

--- a/deploy-scripts/deploy_common.sh
+++ b/deploy-scripts/deploy_common.sh
@@ -21,7 +21,10 @@ BRANCH="master"
 RELEASE_VERSION=$(getProperty "release_version")
 LATEST_PUBLISHED_VERSION=$(curl https://plugins.gradle.org/m2/com/47deg/hood/maven-metadata.xml | grep latest | cut -d'>' -f2 | cut -d'<' -f1)
 if [ "$RELEASE_VERSION" != "$LATEST_PUBLISHED_VERSION" ]; then
-    sed -i "s/version.*/version=$RELEASE_VERSION/g" gradle.properties
+    sed -i "s/version=.*/version=$RELEASE_VERSION/g" gradle.properties
+    echo 'apply from: rootProject.file("gradle/gradle-publish-plugin.gradle")' >> build.gradle
+else
+    echo 'apply from: rootProject.file("gradle/gradle-mvn-push.gradle")' >> build.gradle
 fi
 
 VERSION_NAME=$(getProperty "version")

--- a/deploy-scripts/deploy_release.sh
+++ b/deploy-scripts/deploy_release.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-. $(dirname $0)/deploy_common.sh
 
 VERSION_PATTERN=^[0-9]+\.[0-9]+\.[0-9]+$
 

--- a/deploy-scripts/deploy_snapshot.sh
+++ b/deploy-scripts/deploy_snapshot.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-. $(dirname $0)/deploy_common.sh
 
 VERSION_PATTERN=^[0-9]+\.[0-9]+\.[0-9]+-SNAPSHOT$
 

--- a/gradle/gradle-mvn-push.gradle
+++ b/gradle/gradle-mvn-push.gradle
@@ -1,29 +1,3 @@
-
-def getReleaseRepositoryUrl() {
-  return findProperty("RELEASE_REPOSITORY_URL") ?: "https://api.bintray.com/maven/47deg/hood/hood"
-}
-
-def getSnapshotRepositoryUrl() {
-  return findProperty("SNAPSHOT_REPOSITORY_URL") ?: "https://oss.jfrog.org/artifactory/oss-snapshot-local"
-}
-
-task sourcesJar(type: Jar, dependsOn: classes) {
-  archiveClassifier = "sources"
-  from sourceSets.main.allSource,
-      "build/generated/source/kapt/main",
-      "build/generated/source/kapt/debug",
-      "build/generated/source/kapt/release",
-      "build/generated/source/kaptKotlin/main",
-      "build/generated/source/kaptKotlin/debug",
-      "build/generated/source/kaptKotlin/release",
-      "build/tmp/kapt/main/kotlinGenerated"
-}
-
-task javadocJar(type: Jar, dependsOn: javadoc) {
-  archiveClassifier = "javadoc"
-  from javadoc.destinationDir
-}
-
 publishing {
   publications {
     HoodPublication(MavenPublication) {
@@ -64,9 +38,7 @@ publishing {
   }
   repositories {
     maven {
-      def releasesRepoUrl = getReleaseRepositoryUrl()
-      def snapshotsRepoUrl = getSnapshotRepositoryUrl()
-      url = version.endsWith("SNAPSHOT") ? snapshotsRepoUrl : releasesRepoUrl
+      url = findProperty("SNAPSHOT_REPOSITORY_URL") ?: "https://oss.jfrog.org/artifactory/oss-snapshot-local"
     }
   }
 }

--- a/gradle/gradle-publish-plugin.gradle
+++ b/gradle/gradle-publish-plugin.gradle
@@ -1,0 +1,26 @@
+publishPlugins {
+    dependsOn 'sourcesJar'
+    dependsOn 'javadocJar'
+}
+
+gradlePlugin {
+  plugins {
+    hood {
+      id = "com.47deg.hood"
+      implementationClass = "com.fortysevendeg.hood.HoodPlugin"
+    }
+  }
+}
+
+pluginBundle {
+  website = "https://47degrees.github.io/hood/"
+  vcsUrl = "https://github.com/47degrees/hood"
+  description = "The plugin to manage benchmarks on your CI"
+  tags = ["kotlin", "arrow", "hood", "plugin", "benchmark", "comparison"]
+
+  plugins {
+    hood {
+      displayName = "Hood Gradle Plugin"
+    }
+  }
+}


### PR DESCRIPTION
It separates the configuration to publish into OSS and Gradle Plugin Portal.

It seems it works locally because it tries to publish:

```
https://oss.jfrog.org/artifactory/oss-snapshot-local/com/47deg/hood/0.8.2-SNAPSHOT/maven-metadata.xml
```

instead of:

```
https://oss.jfrog.org/artifactory/oss-snapshot-local/com/47deg/hood/com.47deg.hood.gradle.plugin/0.8.2-SNAPSHOT/maven-metadata.xml
```