### PR TITLE
Integration Xebia Functional

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -4,7 +4,7 @@ name: Hood
 #-------------------------
 description: Hood is a plugin to compare benchmarks and set the result as a Github status and comment on each Pull Request.
 #-------------------------
-author: 47 Degrees
+author: Xebia Functional
 keywords: functional-programming, gradle, kotlin, arrow, scala, sbt, plugin, benchmark, comparison, continuous-integration, github
 #-------------------------
 sidebar-title: Gradle-Hood


### PR DESCRIPTION
In this PR we have changed the references of the 47 Degrees microsite to Xebia Functional. We have not changed the references to the twitter account, web address, Github...